### PR TITLE
Set content of input according to value attribute

### DIFF
--- a/wzk/ui/inlineform/RowBuilder.coffee
+++ b/wzk/ui/inlineform/RowBuilder.coffee
@@ -132,7 +132,7 @@ class wzk.ui.inlineform.RowBuilder extends goog.events.EventTarget
   ###
   removeValues: (row) ->
     for field in row.querySelectorAll('input')
-      field.value = '' if field.type isnt 'hidden'
+      field.value = field.getAttribute('value') if field.type isnt 'hidden'
 
   ###*
     @param {boolean} enabled


### PR DESCRIPTION
The content of input during building a row of an inline form
was set to empty string thus ignoring the "value" attribute
of the input field.
