### PR TITLE
Fixed compiler warning and replaced grid binding css class to js-unique ...

### DIFF
--- a/wzk/app/App.coffee
+++ b/wzk/app/App.coffee
@@ -109,7 +109,7 @@ class wzk.app.App
     @once '.flash', (el) ->
       flash.decorateOrRender el
 
-    @on 'table.grid', (table, dom, xhrFac, opts) ->
+    @on 'table.js-grid', (table, dom, xhrFac, opts) ->
       wzk.ui.grid.build table, dom, xhrFac, opts.app.getRegister(), opts.app.getStorage('g'), opts.flash
 
     @on '.remote-button', (el, dom, xhrFac) ->

--- a/wzk/ui/ac/AutoComplete.coffee
+++ b/wzk/ui/ac/AutoComplete.coffee
@@ -75,7 +75,7 @@ class wzk.ui.ac.AutoComplete extends goog.ui.ac.AutoComplete
     @param {Array} selectedRows
     @return {boolean}
   ###
-  isSelected: (row, selectedRows) =>
+  isSelected: (row, selectedRows) ->
     selectedRows[row.toString()]?
 
   ###*


### PR DESCRIPTION
...one.

I needed separate styles binding and js binding from grid css class.
Because editing is-core is more complicated I decied to edit werzeug so that JS binds Grid class not to .grid but to .js-grid.

So now we can add functions to grids more easily because  we can override function that initializes them, without changing css.